### PR TITLE
List presentations in reverse chronological order

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -327,7 +327,7 @@ function echolink_ess_get_rest_section_presentations($essSection) {
                                         $presentationData[$presentation['id']] = date("Y-m-d H:i", strtotime($presentation['start-time'])) . " ||--|| " . $presentation['title'];
                                 }
                         }
-                        asort($presentationData);
+                        arsort($presentationData);
 
                         $presentationHTML = "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'>";
                         foreach($presentationData as $id => $title) {

--- a/locallib.php
+++ b/locallib.php
@@ -299,48 +299,47 @@ function echolink_ess_get_rest_section($essSection) {
 
 
 function echolink_ess_get_rest_section_presentations($essSection) {
+    // Retrieve ESS Section Presentation XML
+    $sectionPresentationXML = callRestService(ESS_URL, ESS_CONSUMER_KEY, ESS_CONSUMER_SECRET, "sections/$essSection/presentations", "", "GET", array());
 
-        // Retrieve ESS Section Presentation XML
-        $sectionPresentationXML = callRestService(ESS_URL, ESS_CONSUMER_KEY, ESS_CONSUMER_SECRET, "sections/$essSection/presentations", "", "GET", array());
+    if($sectionPresentationXML != null || $sectionPresentationXML != '') {
+        $sectionPresentationJSON = convertXMLtoJSON($sectionPresentationXML, true, true);
 
-        if($sectionPresentationXML != null || $sectionPresentationXML != '') {
-                $sectionPresentationJSON = convertXMLtoJSON($sectionPresentationXML, true, true);
+        if($sectionPresentationJSON['total-results'] == 0) {
+            return "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'><div class='presentationRecord'>&#8226; No Echo360 Presentations are currently available.</div></div>";
+        } else if($sectionPresentationJSON['total-results'] == 1) {
+            if($sectionPresentationJSON['presentation']['status'] == "presentation-status-available") {
+                $id = $sectionPresentationJSON['presentation']['id'];
+                $time = date("Y-m-d H:i", strtotime($sectionPresentationJSON['presentation']['start-time']));
+                $title = $sectionPresentationJSON['presentation']['title'];
 
-                if($sectionPresentationJSON['total-results'] == 0) {
-                        return "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'><div class='presentationRecord'>&#8226; No Echo360 Presentations are currently available.</div></div>";
-                } else if($sectionPresentationJSON['total-results'] == 1) {
-			if($sectionPresentationJSON['presentation']['status'] == "presentation-status-available") {
-				$id = $sectionPresentationJSON['presentation']['id'];
-				$time = date("Y-m-d H:i", strtotime($sectionPresentationJSON['presentation']['start-time']));
-				$title = $sectionPresentationJSON['presentation']['title'];
-
-	                        return "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'>" .
-	                                   "<div class='presentationRecord'>&#8226; <span style='color: gray;'>$time</span> - <i><a href='#' class='ess_presentation_link' id='$id'>$title</a></i>";
-        	                       "</div>";
-			} else {
-                        	return "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'><div class='presentationRecord'>&#8226; No Echo360 Presentations are currently available.</div></div>";
-			}
-                } else {
-                        $presentationData = array();
-                        foreach($sectionPresentationJSON['presentation'] as $presentation) {
-                                if($presentation['status'] == "presentation-status-available") {
-                                        $presentationData[$presentation['id']] = date("Y-m-d H:i", strtotime($presentation['start-time'])) . " ||--|| " . $presentation['title'];
-                                }
-                        }
-                        arsort($presentationData);
-
-                        $presentationHTML = "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'>";
-                        foreach($presentationData as $id => $title) {
-                                $_title = explode(" ||--|| ", $title);
-                                $presentationHTML .= "<div class='presentationRecord'>&#8226; <span style='color: gray;'>" . $_title[0] . "</span> - <i><a href='#' class='ess_presentation_link' id='$id'>" . $_title[1] . "</a></i>";
-                        }
-                        $presentationHTML .= "</div>";
-
-                        return $presentationHTML;
-                }
+                return "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'>" .
+                        "<div class='presentationRecord'>&#8226; <span style='color: gray;'>$time</span> - <i><a href='#' class='ess_presentation_link' id='$id'>$title</a></i>";
+                        "</div>";
+            } else {
+                return "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'><div class='presentationRecord'>&#8226; No Echo360 Presentations are currently available.</div></div>";
+            }
         } else {
-                // Do nothing - error message would have already been displayed
+            $presentationData = array();
+            foreach($sectionPresentationJSON['presentation'] as $presentation) {
+                if($presentation['status'] == "presentation-status-available") {
+                    $presentationData[$presentation['id']] = date("Y-m-d H:i", strtotime($presentation['start-time'])) . " ||--|| " . $presentation['title'];
+                }
+            }
+            arsort($presentationData);
+
+            $presentationHTML = "<div id='presentationLinkData' style='margin-left: 40px; padding-bottom: 5px;'>";
+            foreach($presentationData as $id => $title) {
+                $_title = explode(" ||--|| ", $title);
+                $presentationHTML .= "<div class='presentationRecord'>&#8226; <span style='color: gray;'>" . $_title[0] . "</span> - <i><a href='#' class='ess_presentation_link' id='$id'>" . $_title[1] . "</a></i>";
+            }
+            $presentationHTML .= "</div>";
+
+            return $presentationHTML;
         }
+    } else {
+    // Do nothing - error message would have already been displayed
+    }
 }// end of echolink_ess_get_rest_section_presentations function
 
 


### PR DESCRIPTION
When selecting an Echo, it's likely that you'll be selecting a recent Echo (often the most recent one); displaying the most recent presentation first reduces the amount of scrolling required to find it, especially in sections containing many presentations.

The second commit makes this function more readable by making the indentation consistent (and conform to Moodle coding style); the rest of locallib.php could do with similar treatment, but I've only fixed the indentation in the function I was already working on for now (similar to PR #25).