### PR TITLE
Replace call to deprecated get_all_sections() function

### DIFF
--- a/index.php
+++ b/index.php
@@ -55,7 +55,8 @@ if (!$echolinks = get_all_instances_in_course('echolink', $course)) {
 
 $usesections = course_format_uses_sections($course->format);
 if ($usesections) {
-    $sections = get_all_sections($course->id);
+    $modinfo = get_fast_modinfo($course->id);
+    $sections = $modinfo->get_section_info_all();
 }
 
 $table = new html_table();


### PR DESCRIPTION
get_all_sections() has been deprecated since 2.4.